### PR TITLE
Use a CORS-compatible API call for blockchain.info

### DIFF
--- a/Chrome Extension/test/test.html
+++ b/Chrome Extension/test/test.html
@@ -12,7 +12,7 @@
  
 function get_xcp_encoded(tx_id, addr, callback) {
     
-    var source_html = "http://blockchain.info/rawaddr/"+addr+"?format=json";
+    var source_html = "https://blockchain.info/multiaddr?active="+addr+"&cors=true";
     
     var target_tx = new Array(); 
      


### PR DESCRIPTION
This is the only way I could get the test to work in Chrome on my local machine.
