### PR TITLE
Fix LTBcoin price retrieval from Coincap

### DIFF
--- a/Chrome Extension/popup.js
+++ b/Chrome Extension/popup.js
@@ -386,7 +386,7 @@ function getRate(assetbalance, pubkey, currenttoken){
     if ($("#ltbPrice").html() == "...") {
         
         
-    $.getJSON( "http://www.coincap.io/front/xcp", function( data ) {
+    $.getJSON( "http://www.coincap.io/front/", function( data ) {
     
      $.each(data, function(i, item) {
          var assetname = data[i].short;


### PR DESCRIPTION
Coincap might have changed their API recently... LTBC no longer appears in /front/xcp but still is reported in /front/

https://github.com/CoinCapDev/CoinCap.io
